### PR TITLE
Modify status of Autodesk products

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -197,7 +197,7 @@ _Note: daily releases of this software list are listed, including CSV and JSON f
 | Atlassian     | Crucible | On prem | Vulnerable | Only vulnerable when using non-default config, cloud version fixed |[source](https://confluence.atlassian.com/kb/faq-for-cve-2021-44228-1103069406.html) |
 | Atlassian     | Fisheye | On prem | Vulnerable | Only vulnerable when using non-default config, cloud version fixed |[source](https://confluence.atlassian.com/kb/faq-for-cve-2021-44228-1103069406.html) |
 | Atlassian     | Jira Server & Data Center | On prem | Vulnerable | Only vulnerable when using non-default config, cloud version fixed |[source](https://confluence.atlassian.com/kb/faq-for-cve-2021-44228-1103069406.html) |
-| Autodesk     | All | | Not vuln | | [source](https://www.autodesk.com/trust/overview) |
+| Autodesk     | All | | Investigation | | [source](https://www.autodesk.com/trust/overview) |
 | Avaya         | | | | | [source](https://support.avaya.com/helpcenter/getGenericDetails?detailId=1399839287609) |
 | AVM           | all products | devices, firmware, software incl. MyFritz Service | Not Vuln |  | [source](https://en.avm.de/service/current-security-notifications/) |
 | AXIS          | AXIS OS | All versions | Not Vuln | | [source](https://help.axis.com/axis-os) |


### PR DESCRIPTION
Autodesk state they are still actively investigating their products, moving from current "Not Vuln" status